### PR TITLE
add keyboard shortcut for toggling run paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -861,6 +861,8 @@ angular.module('zeppelinWebApp')
         $scope.insertNew('below');
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 79) { // Ctrl + Alt + o
         $scope.toggleOutput();
+      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 82) { // Ctrl + Alt + r
+        $scope.toggleEnableDisable();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 69) { // Ctrl + Alt + e
         $scope.toggleEditor();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 77) { // Ctrl + Alt + m

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -125,6 +125,17 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">r</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Enable/Disable run paragraph
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Alt</kbd> + <kbd class="kbd-dark">o</kbd>
             </div>
           </div>


### PR DESCRIPTION
### What is this PR for?

Added a keyboard shortcut to toggle enable/disable of running a paragraph
### What type of PR is it?

Improvement
### Todos
### Is there a relevant Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-608
### How should this be tested?

Click in paragraph and press ctrl+alt+s
### Screenshots (if appropriate)

![after](https://cloud.githubusercontent.com/assets/6380209/12334295/ed013684-babe-11e5-8ac2-7bcb63c297aa.png)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? no

Author: Michael Chen miketychen@gmail.com

Closes #638 from MikeTYChen/ZEPPELIN-608 and squashes the following commits:

83cfa85 [Michael Chen] change shortcut key to ctrl+alt+r
1651cde [Michael Chen] Merge branch 'master' into ZEPPELIN-608
aa34352 [Michael Chen] add keyboard shortcut for toggling run paragraph
